### PR TITLE
[ new ] irrefutable patterns in recv/lookup

### DIFF
--- a/Src/Concrete/Base.hs
+++ b/Src/Concrete/Base.hs
@@ -198,4 +198,4 @@ isWin _ = False
 
 type CProtocol = Protocol Raw
 type CJudgementStack = JudgementStack Raw
-type CActor = Actor Variable Variable (Binder Variable) Variable Raw Variable Raw RawP CConnect ()
+type CActor = Actor Variable Variable RawP Variable Raw Variable Raw RawP CConnect ()

--- a/Src/Concrete/Parse.hs
+++ b/Src/Concrete/Parse.hs
@@ -120,7 +120,7 @@ pact = withRange $
   <|> do tm <- ptm
          punc "?"
          case tm of
-           Var _ c -> withVars (`Recv` c) pbinder "." pact
+           Var _ c -> withVars (`Recv` c) ppat "." pact
            t -> withVars (`FreshMeta` t) pvariable "." pact
   <|> Spawn unknown <$> pextractmode <*> pvariable <* punc "@" <*> pvariable <* punc "." <*> pact
   <|> Constrain unknown <$> ptm <* punc "~" <*> pmustwork "Expected a term" ptm
@@ -134,7 +134,7 @@ pact = withRange $
   <|> Print unknown <$ plit "PRINTF" <* pspc <*> (pformat >>= pargs) <* punc "." <*> pact
   <|> Fail unknown <$ pch (== '#') <* pspc <*> (pformat >>= pargs)
   <|> Push unknown <$> pvariable <*> pcurlies ((\ (a, b) -> (a, (), b)) <$> withVar pvariable "->" ptm) <* punc "." <*> pact
-  <|> Lookup unknown <$ plit "lookup" <* pspc <*> ptm <* pspc <*> pcurlies (withVar pbinder "->" pACT)
+  <|> Lookup unknown <$ plit "lookup" <* pspc <*> ptm <* pspc <*> pcurlies (withVar ppat "->" pACT)
              <* pspc <* pmustwork "Expected an else branch" (plit "else") <* pspc <*> pact
   <|> Note unknown <$ plit "!" <* punc "." <*> pact
   <|> pure (Win unknown)

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,8 @@
 * [ ] Industrial-strength parsing
 * [ ] Source location information
 * [ ] Let binders
+* [ ] as-patterns
+* [ ] irrefutable patterns in binders
 
 ### Features
 

--- a/examples/stlctpp2.act
+++ b/examples/stlctpp2.act
@@ -101,7 +101,7 @@ checkEval@p = p?ty. p?tm. case tm
   }
 
 evalSynth@p = p?tm.
-  lookup tm { VT -> case VT { [v | s] -> p!v. p!s. } }
+  lookup tm { [v | s] -> p!v. p!s. }
   else case tm
   { ['Rad rtm ty] -> checkEval@q. q!ty. q!rtm. q?nf. p!['Rad nf ty]. p!ty.
   ; ['App f t] -> evalSynth@q. q!f. q?fnf. q?nfty. case fnf
@@ -195,3 +195,9 @@ exec evalSynth@p.
        ['Cons ['Cons 'Nil ['Cons 'Nil 'Nil]] 'Nil]  -- nil = [2] :: [Nat]
        (\x.\xs.\ih.['Cons ['Emb x] ['Emb ih]])].    -- cons(x,xs,ih) = x : xs
   p?nf. p?ty. PRINTF "Result:\n[0,1] ++ [2]\n  : %i\n  = %i" ty nf.
+
+{-
+exec evalSynth@p.
+  p!['Rad ['Lam \a. ['Emb ['App ['Rad ['Lam \x. ['Emb x]] ['Arr 'One 'One]] ['Emb a]]]] ['Arr 'One 'One]].
+  p?nf. p?ty. PRINTF "%i : %i" nf ty.
+-}

--- a/test/communicating-pairs.act
+++ b/test/communicating-pairs.act
@@ -1,0 +1,15 @@
+syntax { 'Ping = ['Enum ['Ping]]
+       ; 'Pong = ['Enum ['Pong]]
+       }
+
+unpack : ?['Cons 'Ping 'Pong]. !'Ping. !'Pong.
+pack : ?'Ping. ?'Pong. !['Cons 'Ping 'Pong].
+
+unpack@p = p?[fst | snd]. p!fst. p!snd.
+pack@p = p?fst. p?snd. p![fst | snd].
+
+exec pack@p. p!'Ping. p!'Pong. p?both.
+     unpack@q. q!both. q?fst snd.
+     case fst { 'Ping ->
+     case snd { 'Pong ->
+     PRINTF "Success". }}

--- a/test/golden/communicating-pairs.gold
+++ b/test/golden/communicating-pairs.gold
@@ -1,0 +1,5 @@
+ret > ExitSuccess
+out > Success
+out >
+err >
+err >


### PR DESCRIPTION
I've been really annoyed by the whole `p?v. case v { [p | q] -> ...}` pattern so here we go.