### PR TITLE
[refactor] `MachineSteps` should not be defined in `Options`

### DIFF
--- a/Src/Command.hs
+++ b/Src/Command.hs
@@ -26,6 +26,7 @@ import Elaboration.Pretty()
 import Machine.Base
 import Machine.Display (Store)
 import Machine.Exec
+import Machine.Steps
 import Machine.Trace (Shots)
 import Options
 import Parse

--- a/Src/Machine/Base.hs
+++ b/Src/Machine/Base.hs
@@ -24,6 +24,7 @@ import Concrete.Base (Root, Guard, ExtractMode, ACTOR (..), Operator(..))
 import Syntax (SyntaxDesc)
 import Data.Bifunctor (Bifunctor(first))
 
+import Machine.Steps
 import Machine.Matching
 import Debug.Trace (trace)
 import Display (unsafeDocDisplayClosed)

--- a/Src/Machine/Display.hs
+++ b/Src/Machine/Display.hs
@@ -16,7 +16,7 @@ import Elaboration.Pretty()
 import Forget
 import Format
 import Machine.Base
-import Options
+import Machine.Steps
 import Pretty
 import Term
 import Term.Display ()

--- a/Src/Machine/Exec.hs
+++ b/Src/Machine/Exec.hs
@@ -28,6 +28,7 @@ import Actor
 import Machine.Base
 import Machine.Display
 import Machine.Matching
+import Machine.Steps
 import Machine.Trace
 
 import System.IO.Unsafe

--- a/Src/Machine/Steps.hs
+++ b/Src/Machine/Steps.hs
@@ -2,9 +2,15 @@
 {- | Description: 
 
 -}
-module Machine.Steps where
+module Machine.Steps (
+    MachineStep(..)
+  , readSteps , tracingHelp
+  ) where
 
-import Pretty (Pretty(pretty))
+import Options.Applicative (ReadM, readerError)
+import Data.Tuple (swap)
+
+import Pretty (Pretty(pretty), text, render, vcat, Doc, Annotations, hsep)
 
 -- | Define the steps that the machine can take
 data MachineStep
@@ -17,13 +23,43 @@ data MachineStep
   | MachineClause
   deriving (Eq, Show, Enum, Bounded)
 
+-- | Pair up 'MachineStep' with its 'String'
+namesOfSteps :: [(MachineStep, String)]
+namesOfSteps =
+  [ ( MachineRecv , "recv")
+  , ( MachineSend , "send")
+  , ( MachineExec , "exec")
+  , ( MachineMove , "move")
+  , ( MachineUnify , "unify")
+  , ( MachineBreak , "break")
+  , ( MachineClause , "clause")
+  ]
+
 -- | Output 'MachineStep' in a way that's nicer for humans
 instance Pretty MachineStep where
-  pretty = \case
-    MachineRecv -> "recv"
-    MachineSend -> "send"
-    MachineExec -> "exec"
-    MachineMove -> "move"
-    MachineUnify -> "unify"
-    MachineBreak -> "break"
-    MachineClause -> "clause"
+  pretty m = case (lookup m namesOfSteps) of
+    Just n -> text n
+    Nothing -> error "impossible: a MachineStep has no name?"
+
+-- | What are the steps that the machine can take?
+theSteps :: [Doc Annotations]
+theSteps = map (text.snd) namesOfSteps
+
+-- | Read a single step
+aStep :: String -> ReadM MachineStep
+aStep s = case lookup s (map swap namesOfSteps) of
+  Just x -> pure x
+  Nothing -> readerError $ "Unknown tracing level '" ++ s ++ "'. " ++ allowedLevels
+    where
+       allowedLevels = "Accepted levels:\n" ++ (render . vcat $ theSteps)
+
+-- | Read all the steps to trace
+readSteps :: [String] -> ReadM [MachineStep]
+readSteps = mapM aStep
+
+-- | String to print out to let users know what tracing levels there are
+tracingHelp :: String
+tracingHelp = "Override tracing level (combinations of {" ++ levels ++ "} in quotes, separated by spaces, e.g. " ++ exampleLevels ++ ")"
+  where
+    levels = render $ vcat theSteps
+    exampleLevels = "\"" ++ render (hsep $ map (pretty.fst) namesOfSteps ) ++ "\""

--- a/Src/Machine/Steps.hs
+++ b/Src/Machine/Steps.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{- | Description: 
+{- | Description:
 
 -}
 module Machine.Steps (
@@ -23,23 +23,23 @@ data MachineStep
   | MachineClause
   deriving (Eq, Show, Enum, Bounded)
 
+stepName :: MachineStep -> String
+stepName = \case
+  MachineRecv -> "recv"
+  MachineSend -> "send"
+  MachineExec -> "exec"
+  MachineMove -> "move"
+  MachineUnify -> "unify"
+  MachineBreak -> "break"
+  MachineClause -> "clause"
+
 -- | Pair up 'MachineStep' with its 'String'
 namesOfSteps :: [(MachineStep, String)]
-namesOfSteps =
-  [ ( MachineRecv , "recv")
-  , ( MachineSend , "send")
-  , ( MachineExec , "exec")
-  , ( MachineMove , "move")
-  , ( MachineUnify , "unify")
-  , ( MachineBreak , "break")
-  , ( MachineClause , "clause")
-  ]
+namesOfSteps = map (\ x -> (x, stepName x)) [minBound..maxBound]
 
 -- | Output 'MachineStep' in a way that's nicer for humans
 instance Pretty MachineStep where
-  pretty m = case (lookup m namesOfSteps) of
-    Just n -> text n
-    Nothing -> error "impossible: a MachineStep has no name?"
+  pretty = text . stepName
 
 -- | What are the steps that the machine can take?
 theSteps :: [Doc Annotations]

--- a/Src/Machine/Steps.hs
+++ b/Src/Machine/Steps.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+{- | Description: 
+
+-}
+module Machine.Steps where
+
+import Pretty (Pretty(pretty))
+
+-- | Define the steps that the machine can take
+data MachineStep
+  = MachineRecv
+  | MachineSend
+  | MachineExec
+  | MachineMove
+  | MachineUnify
+  | MachineBreak
+  | MachineClause
+  deriving (Eq, Show, Enum, Bounded)
+
+-- | Output 'MachineStep' in a way that's nicer for humans
+instance Pretty MachineStep where
+  pretty = \case
+    MachineRecv -> "recv"
+    MachineSend -> "send"
+    MachineExec -> "exec"
+    MachineMove -> "move"
+    MachineUnify -> "unify"
+    MachineBreak -> "break"
+    MachineClause -> "clause"

--- a/Src/Options.hs
+++ b/Src/Options.hs
@@ -11,7 +11,7 @@ import System.Environment (getEnv)
 
 import qualified ANSI
 import Machine.Steps
-import Pretty (Pretty(pretty),Annotations,render,vcat,hsep,toANSIs)
+import Pretty (Annotations,toANSIs)
 import qualified Text.PrettyPrint.Compact as Compact
 
 data Options = Options
@@ -51,20 +51,6 @@ poptions = Options
   <*> optional (option str (metavar "FILE" <> long "latex-animated" <> completer (bashCompleter "file") <> help "Output animated LaTeX derivation to FILE"))
   <*> pure 80 -- dummy value
   <*> flag False True (long "no-context" <> help "Do not print file context of errors")
- where
-   readSteps :: [String] -> ReadM [MachineStep]
-   readSteps = mapM $ \case
-     "recv" -> pure MachineRecv
-     "send" -> pure MachineSend
-     "exec" -> pure MachineExec
-     "move" -> pure MachineMove
-     "unify" -> pure MachineUnify
-     "break" -> pure MachineBreak
-     "clause" -> pure MachineClause
-     x -> readerError $ "Unknown tracing level '" ++ x ++ "'. Accepted levels:\n" ++ levels
-   tracingHelp = "Override tracing level (combinations of {" ++ levels ++ "} in quotes, separated by spaces, e.g. " ++ exampleLevels ++ ")"
-   levels = render $ vcat $ map pretty [(minBound::MachineStep)..]
-   exampleLevels = "\"" ++ render (hsep $ map pretty [minBound::MachineStep, maxBound]) ++ "\""
 
 getOptions :: IO Options
 getOptions = do

--- a/Src/Options.hs
+++ b/Src/Options.hs
@@ -1,34 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
+{- | Description: 
 
+-}
 module Options where
 
-import Options.Applicative
+-- from the optparse-applicative package
+import Options.Applicative 
 import System.Console.Terminal.Size (size, width)
 import System.Environment (getEnv)
 
 import qualified ANSI
-import Pretty
+import Machine.Steps
+import Pretty (Pretty(pretty),Annotations,render,vcat,hsep,toANSIs)
 import qualified Text.PrettyPrint.Compact as Compact
-
-data MachineStep
-  = MachineRecv
-  | MachineSend
-  | MachineExec
-  | MachineMove
-  | MachineUnify
-  | MachineBreak
-  | MachineClause
-  deriving (Eq, Show, Enum, Bounded)
-
-instance Pretty MachineStep where
-  pretty = \case
-    MachineRecv -> "recv"
-    MachineSend -> "send"
-    MachineExec -> "exec"
-    MachineMove -> "move"
-    MachineUnify -> "unify"
-    MachineBreak -> "break"
-    MachineClause -> "clause"
 
 data Options = Options
   { filename :: String

--- a/typos.cabal
+++ b/typos.cabal
@@ -53,6 +53,7 @@ library
                        Machine.Display,
                        Machine.Exec,
                        Machine.Matching,
+                       Machine.Steps,
                        Machine.Trace,
                        Main,
                        Options,


### PR DESCRIPTION
Remove the definition of `MachineSteps` from `Options` and put it in `Machine.Steps` instead.