### PR TITLE
[doc] document Parse (and refactor a bit)

### DIFF
--- a/Src/Command.hs
+++ b/Src/Command.hs
@@ -171,16 +171,16 @@ pmachinestep =
   <|> MachineBreak <$ plit "break"
 
 pjudgeat :: Parser (Variable, (), Variable)
-pjudgeat = (,,) <$> pvariable <*> punc "@" <*> pvariable
+pjudgeat = (,,) <$> pvariable <*> ppunc "@" <*> pvariable
 
 psyntax :: Parser (WithRange SyntaxCat, Raw)
-psyntax = (,) <$> pwithRange patom <* punc "=" <*> psyntaxdecl
+psyntax = (,) <$> pwithRange patom <* ppunc "=" <*> psyntaxdecl
 
 pstatement :: Parser CStatement
 pstatement = Statement <$> pvariable <*> many (id <$ pspc <*> pvariable)
 
 pconditions :: Parser [CStatement]
-pconditions = pcurlies (psep (punc ",") pstatement)
+pconditions = pcurlies (psep (ppunc ",") pstatement)
 
 poperator :: Parser a -> Parser (WithRange String, [a])
 poperator ph =
@@ -190,26 +190,26 @@ poperator ph =
 panoperator :: Parser CAnOperator
 panoperator = do
   obj <- psyntaxdecl
-  punc "-"
+  ppunc "-"
   (opname, params) <- poperator psyntaxdecl
-  punc "~>"
+  ppunc "~>"
   ret <- psyntaxdecl
   pure (AnOperator opname obj params ret)
 
 pcommand :: Parser CCommand
 pcommand
-    = DeclJudge <$> pextractmode <*> pvariable <* punc ":" <*> pprotocol
-  <|> DefnJudge <$> pjudgeat <* punc "=" <*> pACT
+    = DeclJudge <$> pextractmode <*> pvariable <* ppunc ":" <*> pprotocol
+  <|> DefnJudge <$> pjudgeat <* ppunc "=" <*> pACT
   <|> ContractJudge <$> pconditions <* pspc <*> pstatement <* pspc <*> pconditions
-  <|> DeclSyntax <$ plit "syntax" <*> pcurlies (psep (punc ";") psyntax)
-  <|> DeclStack <$> pvariable <* punc "|-" <*> pcontextstack
+  <|> DeclSyntax <$ plit "syntax" <*> pcurlies (psep (ppunc ";") psyntax)
+  <|> DeclStack <$> pvariable <* ppunc "|-" <*> pcontextstack
   <|> ContractStack <$> pconditions <* pspc
-                    <*> ((,,) <$> pvariable <* punc "|-" <*> pvariable <* punc "->" <*> pvariable)
+                    <*> ((,,) <$> pvariable <* ppunc "|-" <*> pvariable <* ppunc "->" <*> pvariable)
                     <* pspc <*> pconditions
   <|> Go <$ plit "exec" <* pspc <*> pACT
-  <|> Trace <$ plit "trace" <*> pcurlies (psep (punc ",") pmachinestep)
-  <|> DeclOp <$ plit "operator" <*> pcurlies (psep (punc ";") panoperator)
-  <|> DefnOp <$> ((,,) <$> ppat <*> some (punc "-" *> poperator ppat) <* punc "~>" <*> pTM)
+  <|> Trace <$ plit "trace" <*> pcurlies (psep (ppunc ",") pmachinestep)
+  <|> DeclOp <$ plit "operator" <*> pcurlies (psep (ppunc ";") panoperator)
+  <|> DefnOp <$> ((,,) <$> ppat <*> some (ppunc "-" *> poperator ppat) <* ppunc "~>" <*> pTM)
 
 pfile :: Parser [CCommand]
 pfile = id <$ pspc <*> psep pspc pcommand <* pspc

--- a/Src/Concrete/Parse.hs
+++ b/Src/Concrete/Parse.hs
@@ -61,8 +61,8 @@ ptm :: Parser Raw
 ptm = withRange $
   Var unknown <$> pvariable
   <|> At unknown <$> patom
-  <|> plisp Nothing
-  -- <|> id <$ pch (== '[') <* pspc <*> plisp
+  -- <|> plisp Nothing
+  <|> id <$ pch (== '[') <* pspc <*> plisp
   <|> pparens pTM
 
 psbstC :: Parser SbstC
@@ -81,8 +81,8 @@ ppat = withRange $
   AsP unknown <$> pvariable <* ppunc "@" <*> ppat
   <|> VarP unknown <$> pvariable
   <|> AtP unknown <$> patom
-  <|> plisp (Just $ pmustwork "Expected a list pattern")
-  -- <|> id <$ pch (== '[') <* pspc <*> pmustwork "Expected a list pattern" plisp
+  -- <|> plisp (Just $ pmustwork "Expected a list pattern")
+  <|> id <$ pch (== '[') <* pspc <*> pmustwork "Expected a list pattern" plisp
   <|> pparens ppat
   <|> pscoped LamP pbinder ppat
   <|> ThP unknown <$ pch (== '{') <* pspc <*> pth <* ppunc "}" <*> ppat
@@ -150,8 +150,8 @@ pscrutinee = withRange $ do
   <|> Compare unknown <$ pkeyword KwCompare <* pspc1 <*> pTM <* pspc <*> pTM
   <|> pparens pscrutinee
   <|> Term unknown <$> pTM
-  <|> (isProper =<< plisp Nothing) where
-  -- id <$ pch (== '[') <* pspc <*> plisp) where
+  -- <|> (isProper =<< plisp Nothing) where
+  <|> (isProper =<< id <$ pch (== '[') <* pspc <*> plisp) where
 
     isProper :: CScrutinee -> Parser CScrutinee
     isProper (Term _ _) = pfail

--- a/Src/Concrete/Parse.hs
+++ b/Src/Concrete/Parse.hs
@@ -23,7 +23,7 @@ pscoped con px pa = do
     pspc
     xs <- pmustwork "Expected at least a binder" $
           psep1 pspc (Hide <$> px)
-    punc "."
+    ppunc "."
     a <- pa
     pure (xs, a)
   pure $ foldr (\ x a -> con r (Scope x a)) a xs
@@ -48,25 +48,26 @@ pTM :: Parser Raw
 pTM = withRange $
   (ptm >>= more)
   <|> pscoped Lam pbinder pTM
-  <|> Sbst unknown <$ pch (== '{') <* pspc <*> ppes (punc ",") psbstC <* punc "}" <*> pTM
+  <|> Sbst unknown <$ pch (== '{') <* pspc <*> ppes (ppunc ",") psbstC <* ppunc "}" <*> pTM
 
   where
 
   more :: Raw -> Parser Raw
   more t = withRange $
-    ((Op unknown t <$ punc "-" <*> ptm) >>= more)
+    ((Op unknown t <$ ppunc "-" <*> ptm) >>= more)
     <|> pure t
 
 ptm :: Parser Raw
 ptm = withRange $
   Var unknown <$> pvariable
   <|> At unknown <$> patom
-  <|> id <$ pch (== '[') <* pspc <*> plisp
+  <|> plisp Nothing
+  -- <|> id <$ pch (== '[') <* pspc <*> plisp
   <|> pparens pTM
 
 psbstC :: Parser SbstC
 psbstC = withRange $ pvariable >>= \ x ->
-  Assign unknown x <$ punc "=" <*> pTM
+  Assign unknown x <$ ppunc "=" <*> pTM
   <|> Drop unknown x <$ pspc <* pch (== '*')
   <|> pure (Keep unknown x)
 
@@ -77,13 +78,14 @@ instance Lisp RawP where
 
 ppat :: Parser RawP
 ppat = withRange $
-  AsP unknown <$> pvariable <* punc "@" <*> ppat
+  AsP unknown <$> pvariable <* ppunc "@" <*> ppat
   <|> VarP unknown <$> pvariable
   <|> AtP unknown <$> patom
-  <|> id <$ pch (== '[') <* pspc <*> pmustwork "Expected a list pattern" plisp
+  <|> plisp (Just $ pmustwork "Expected a list pattern")
+  -- <|> id <$ pch (== '[') <* pspc <*> pmustwork "Expected a list pattern" plisp
   <|> pparens ppat
   <|> pscoped LamP pbinder ppat
-  <|> ThP unknown <$ pch (== '{') <* pspc <*> pth <* punc "}" <*> ppat
+  <|> ThP unknown <$ pch (== '{') <* pspc <*> pth <* ppunc "}" <*> ppat
   <|> UnderscoreP unknown <$ pch (== '_')
 
 pth :: Parser (Bwd Variable, ThDirective)
@@ -107,24 +109,24 @@ psyntaxdecl = pTM
 pcontextstack :: Parser (ContextStack Raw)
 pcontextstack = ContextStack
   <$> psyntaxdecl
-  <* punc "->"
+  <* ppunc "->"
   <*> pmustwork "Expected a syntax declaration" psyntaxdecl
 
 pACT :: Parser CActor
 pACT = withRange (pact >>= more) where
 
   more :: CActor -> Parser CActor
-  more act = Branch unknown act <$ punc "|" <*> pmustwork "Expected an actor" pACT
+  more act = Branch unknown act <$ ppunc "|" <*> pmustwork "Expected an actor" pACT
     <|> pure act
 
 withVar :: Parser x -> String -> Parser a -> Parser (x, a)
-withVar px str p = (,) <$> px <* punc str <*> p
+withVar px str p = (,) <$> px <* ppunc str <*> p
 
 withVars :: (Range -> (x, a) -> a) -> Parser x -> String -> Parser a -> Parser a
 withVars con px str pa = do
   WithRange r (xs, a) <- withRange $ WithRange unknown <$> do
     xs <- psep1 pspc px
-    punc str
+    ppunc str
     a <- pa
     pure (xs, a)
   pure $ foldr (curry (con r)) a xs
@@ -148,7 +150,8 @@ pscrutinee = withRange $ do
   <|> Compare unknown <$ pkeyword KwCompare <* pspc1 <*> pTM <* pspc <*> pTM
   <|> pparens pscrutinee
   <|> Term unknown <$> pTM
-  <|> (isProper =<< id <$ pch (== '[') <* pspc <*> plisp) where
+  <|> (isProper =<< plisp Nothing) where
+  -- id <$ pch (== '[') <* pspc <*> plisp) where
 
     isProper :: CScrutinee -> Parser CScrutinee
     isProper (Term _ _) = pfail
@@ -157,29 +160,29 @@ pscrutinee = withRange $ do
 pact :: Parser CActor
 pact = withRange $
   pscoped Under pvariable pact
-  <|> Send unknown <$> pvariable <*> pure () <* punc "!" <*> pmustwork "Expected a term" pTM <* punc "." <*> pact
+  <|> Send unknown <$> pvariable <*> pure () <* ppunc "!" <*> pmustwork "Expected a term" pTM <* ppunc "." <*> pact
   <|> do tm <- pTM
-         punc "?"
+         ppunc "?"
          case tm of
            Var _ c -> withVars (`Recv` c) ppat "." pact
            t -> withVars (`FreshMeta` t) pvariable "." pact
-  <|> Let unknown <$ pkeyword KwLet <* pspc1 <*> pvariable <* punc ":" <*> psyntaxdecl
-                  <* punc "=" <*> pTM <* punc "." <*> pact
-  <|> Spawn unknown <$> pextractmode <*> pvariable <* punc "@" <*> pvariable <* punc "." <*> pact
-  <|> Constrain unknown <$> pTM <* punc "~" <*> pmustwork "Expected a term" pTM
-  <|> Connect unknown <$> (CConnect <$> pvariable <* punc "<->" <*> pvariable)
-  <|> Match unknown <$> pcase <* punc "{"
-       <*> psep (punc ";") ((,) <$> ppat <* punc "->" <*> pACT)
+  <|> Let unknown <$ pkeyword KwLet <* pspc1 <*> pvariable <* ppunc ":" <*> psyntaxdecl
+                  <* ppunc "=" <*> pTM <* ppunc "." <*> pact
+  <|> Spawn unknown <$> pextractmode <*> pvariable <* ppunc "@" <*> pvariable <* ppunc "." <*> pact
+  <|> Constrain unknown <$> pTM <* ppunc "~" <*> pmustwork "Expected a term" pTM
+  <|> Connect unknown <$> (CConnect <$> pvariable <* ppunc "<->" <*> pvariable)
+  <|> Match unknown <$> pcase <* ppunc "{"
+       <*> psep (ppunc ";") ((,) <$> ppat <* ppunc "->" <*> pACT)
        <* pspc <* pch (== '}')
   <|> pparens pACT
-  <|> Break unknown <$ pkeyword KwBREAK <* pspc1 <*> (pformat >>= pargs) <* punc "." <*> pact
-  <|> Print unknown <$ pkeyword KwPRINT <* pspc1 <*> pargs [TermPart Instantiate ()] <* punc "." <*> pact
-  <|> Print unknown <$ pkeyword KwPRINTF <* pspc1 <*> (pformat >>= pargs) <* punc "." <*> pact
+  <|> Break unknown <$ pkeyword KwBREAK <* pspc1 <*> (pformat >>= pargs) <* ppunc "." <*> pact
+  <|> Print unknown <$ pkeyword KwPRINT <* pspc1 <*> pargs [TermPart Instantiate ()] <* ppunc "." <*> pact
+  <|> Print unknown <$ pkeyword KwPRINTF <* pspc1 <*> (pformat >>= pargs) <* ppunc "." <*> pact
   <|> Fail unknown <$ pch (== '#') <* pspc <*> (pformat >>= pargs)
-  <|> Push unknown <$> pvariable <* punc "|-"
+  <|> Push unknown <$> pvariable <* ppunc "|-"
                    <*> ((\ (a, b) -> (a, (), b)) <$> withVar pvariable "->" pTM)
-                   <* punc "." <*> pact
-  <|> Note unknown <$ plit "!" <* punc "." <*> pact
+                   <* ppunc "." <*> pact
+  <|> Note unknown <$ plit "!" <* ppunc "." <*> pact
   <|> pure (Win unknown)
   where
     -- allows `case$ x` to stand for `case $ x`

--- a/Src/Parse.hs
+++ b/Src/Parse.hs
@@ -315,11 +315,18 @@ class Lisp t where
   pCar   :: Parser t
 
 -- Parse a lispy language, with an optional transformer
+plisp :: (Lisp t, HasRange t) => Parser t
+plisp = withRange $
+  mkNil <$ plit "]"
+  <|> id <$ plit "|" <* pspc <*> pCar <* pspc <* plit "]"
+  <|> mkCons <$> pCar <* pspc <*> plisp
+{-
 plisp :: (Lisp t, HasRange t) => Maybe (Parser t -> Parser t) -> Parser t
 plisp tr = maybe (doit id) (doit) tr
   where
     doit :: (Lisp t, HasRange t) => (Parser t -> Parser t) -> Parser t
-    doit tr = withRange $ id <$ pch (== '[') <* pspc <*> tr (
+    doit tr = id <$ pch (== '[') <* pspc <*> tr (withRange $
       mkNil <$ plit "]"
       <|> id <$ plit "|" <* pspc <*> pCar <* pspc <* plit "]"
       <|> mkCons <$> pCar <* pspc <*> plisp Nothing)
+-}

--- a/Src/Parse.hs
+++ b/Src/Parse.hs
@@ -1,136 +1,38 @@
+{- Description: Parser utilities for the external syntax -}
 module Parse where
 
-import Control.Applicative
-import Control.Monad
+import Control.Applicative (Alternative(..))
+import Control.Monad (when, ap)
 
-import Data.Bifunctor
-import Data.Char
-import Data.Function
+import Data.Bifunctor (first, bimap)
+import Data.Char (isSpace, isAlphaNum, isAlpha, isDigit)
+import Data.Function (on)
 
-import Bwd
-import Location
+import Bwd (Bwd(..),(<><), unzipWith, nub, (<>>))
+import Location (Location, HasRange, WithRange(WithRange), tick, ticks, addRange, unknown)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Exit (exitFailure)
 import Data.List (intercalate)
 import Data.Foldable (fold)
 
--- parsers, by convention, do not consume either leading
--- or trailing space
+-- Even though Haskell does not require this, the functions below
+-- are nevertheless mostly ordered by dependency.
 
-plit :: String -> Parser ()
-plit cs = Expected ("'" ++ cs ++ "'") <!> mapM_ (pch . (==)) cs
-
-punc :: String -> Parser ()
-punc cs = () <$ pspc <* plit cs <* pspc
-
-pparens :: Parser a -> Parser a
-pparens p = id <$ pch (== '(') <* pspc <*> p <* pspc <* plit ")"
-
-pcurlies :: Parser a -> Parser a
-pcurlies p = id <$ punc "{" <*> p <* pspc <* plit "}"
-
-pstring :: Parser String
-pstring = Parser $ \ (Source str loc) -> case str of
-  '"' : str -> maybe (notHere loc) here (go str (tick loc '"'))
-  _ -> notHere loc
-
-  where
-
-  go :: String -> Location -> Maybe (String, Source)
-  go str loc =
-    let (pref, end) = span (`notElem` "\\\"") str in
-    let loc' = ticks loc pref in
-    case end of
-      '\\':'"':end -> first ((pref ++) . ('"' :)) <$> go end (ticks loc "\\\"")
-      '\\':end -> first ((pref ++) . ('\\' :)) <$> go end (tick loc' '\\')
-      '"':end -> pure (pref, Source end (tick loc' '\"'))
-      _ -> Nothing
-
-
-pnat :: Parser Int
-pnat = Parser $ \ (Source str loc) -> case span isDigit str of
-  (ds@(_:_), str) -> here (read ds, Source str (ticks loc ds))
-  _ -> notHere loc
-
-pnom :: Parser String
-pnom = Parser $
-  let isMo c = isAlphaNum c || elem c "_'" in
-  \ (Source str loc) -> case str of
-  c : cs | isAlpha c -> case span isMo cs of
-      (nm, str) -> here (c:nm, Source str (ticks loc (c : nm)))
-  _ -> notHere loc
-
-patom :: Parser String
-patom = pch (== '\'') *> pnom
-
--- | Returns whether a comment was found
-pcom :: Parser Bool
-pcom = Parser $ \ i@(Source str loc) -> here $ case str of
-  '{':'-':str -> (True, multiLine 1 str (ticks loc "{-"))
-  '-':'-':str -> (True, singleLine str (ticks loc "--"))
-  _ -> (False, i)
-
-  where
-
-  multiLine :: Int -> String -> Location -> Source
-  multiLine 0 str loc = Source str loc
-  multiLine n str loc =
-    let (pref, rest) = span (`notElem` "{-") str in
-    let loc' = ticks loc pref in
-    case rest of
-      -- closing
-      '-':'}':str -> multiLine (n-1) str (ticks loc' "-}")
-      -- starting
-      '{':'-':str -> multiLine (1+n) str (ticks loc' "{-")
-      '-':'-':str ->
-        let Source end loc'' = singleLine str (ticks loc' "--") in
-        multiLine n end loc''
-      -- false alarm: ignore the unrelated '-'/'{'
-      c:str -> multiLine n str (tick loc' c)
-      -- unclosed bracket which is fine by us
-      [] -> Source [] loc'
-
-  singleLine :: String -> Location -> Source
-  singleLine str loc = case span (/= '\n') str of
-    (cs, []) -> Source [] (ticks loc cs)
-    (cs, d:ds) -> Source ds (tick (ticks loc cs) d)
-
--- Remove leading spaces, an optional comment, and repeat
-pspc :: Parser ()
-pspc = do
-  Parser $ \ (Source str loc) ->
-           let (cs, rest) = span isSpace str in
-           here ((), Source rest (ticks loc cs))
-  b <- pcom
-  when b pspc
-
-pspc1 :: Parser ()
-pspc1 = do
-  b <- pcom
-  when (not b) $ () <$ pch isSpace
-  pspc
-
-pnl :: Parser ()
-pnl = () <$ pch (\c -> c == '\n' || c == '\0')
-
-psep1 :: Parser () -> Parser a -> Parser [a]
-psep1 s p = (:) <$> p <* s <*> psep s p
-
-psep :: Parser () -> Parser a -> Parser [a]
-psep s p = (:) <$> p <*> many (id <$ s <*> p)
- <|> pure []
-
-ppes :: Parser () -> Parser{--}a -> Parser (Bwd a)
-ppes s p = (B0 <><) <$> psep s p
-
+----------------------------------------------------------------------
+-- | A 'Source' is some content (as a String) which comes from a 'Location'
 data Source = Source
-  { content :: String
-  , location :: Location
+  { content :: String    -- what we're parsing
+  , location :: Location -- where it came from
   } deriving (Show)
 
+----------------------------------------------------------------------
+-- | A 'Hint' is either what we expect, or something else.
+-- These 'Expected' is used to give better error messages when we encounter something
+-- that is not expected.
 data Hint = Expected String | Other String
   deriving (Show, Eq)
 
+-- | Hints usually come as (snoc) lists, and we want to show them nicely
 renderHints :: Bwd Hint -> String
 renderHints descs =
   let (es, ds) = bimap fold fold $ flip unzipWith (nub descs) $ \case
@@ -144,13 +46,17 @@ renderHints descs =
   in
   intercalate "\n" (e ++ ds)
 
+----------------------------------------------------------------------
+-- | A Candidate is a 'Location' as well as a (snoc) list of 'Hint's.
 data Candidate = Candidate
   { description :: Bwd Hint
   , candidateLoc :: Location
   }
 
+-- | Candidates are equal when they are in the same place
 instance Eq Candidate where (==) = (==) `on` candidateLoc
 
+-- | The 'Semigroup' structure is induced by the order.
 instance Semigroup Candidate where
   c1@(Candidate ds1 loc1) <> c2@(Candidate ds2 loc2) =
     case compare loc1 loc2 of
@@ -158,38 +64,31 @@ instance Semigroup Candidate where
       EQ -> Candidate (ds1 <> ds2) loc1
       GT -> c1
 
+----------------------------------------------------------------------
+-- Where are the candidates for a parse?
+
+-- | here says that what we want to parse is located 'here'
+-- (and, implicitly, that there is just one of them)
+here :: (a, Source) -> (Candidate, [(a, Source)])
+here (a, s) = (Candidate B0 (location s), [(a, s)])
+
+-- | notHere says that whatever is here, is not what we want
+notHere :: Location -> (Candidate, [(a, Source)])
+notHere loc = (Candidate B0 loc, [])
+
+----------------------------------------------------------------------
+-- Conventions:
+-- - parsers do not consume either leading or trailing space
+-- - pieces of parsers start with 'p' in their name.
+-- - documentation below will not say "parse X", just X
+
+-- | A 'Parser' for type a is a function from a 'Source' to a pair of a 'Candidate' (parse)
+-- and a list of (a, Source), i.e. a list of successes and remainders.
 newtype Parser a = Parser
   { parser :: Source -> (Candidate, [(a, Source)])
   }
 
-pfail :: Parser a
-pfail = Parser (notHere . location)
-
-infix 0 <!>
-(<!>) :: Hint -> Parser a -> Parser a
-desc <!> p = Parser $ \ src ->
-  let (Candidate mdesc loc, res) = parser p src in
-  (Candidate (mdesc :< desc) loc, res)
-
-here :: (a, Source) -> (Candidate, [(a, Source)])
-here (a, s) = (Candidate B0 (location s), [(a, s)])
-
-notHere :: Location -> (Candidate, [(a, Source)])
-notHere loc = (Candidate B0 loc, [])
-
-ploc :: Parser Location
-ploc = Parser $ \ i@(Source str loc) -> here (loc, i)
-
-withRange :: HasRange t => Parser t -> Parser t
-withRange p = do
-   start <- ploc
-   x <- p
-   end <- ploc
-   pure $ addRange start end x
-
-pwithRange :: Parser a -> Parser (WithRange a)
-pwithRange p = withRange (WithRange unknown <$> p)
-
+-- Parsers have a lot of structure: Alternative Monads.
 instance Monad Parser where
   Parser f >>= k = Parser $ \ s ->
     let (loc, as) = f s in
@@ -208,46 +107,219 @@ instance Alternative Parser where
   Parser f <|> Parser g = Parser $ \ s ->
     f s <> g s
 
+----------------------------------------------------------------------
+-- And now for some actual parsers
+
+-- | Collection of characters, given by a selection function
 pch :: (Char -> Bool) -> Parser Char
 pch p = Parser $ \ (Source s loc) -> case s of
   c : cs | p c -> here (c, Source cs (tick loc c))
   _ -> notHere loc
 
+-- | Annotation a 'Parser' with a 'Hint'
+infix 0 <!>
+(<!>) :: Hint -> Parser a -> Parser a
+desc <!> p = Parser $ \ src ->
+  let (Candidate mdesc loc, res) = parser p src in
+  (Candidate (mdesc :< desc) loc, res)
 
+-- | literals; make sure to remember what is actually expected.
+plit :: String -> Parser ()
+plit cs = Expected ("'" ++ cs ++ "'") <!> mapM_ (pch . (==)) cs
+
+-- | Returns whether a comment was found, and leave lots of 
+-- information about the comment in the location
+pcom :: Parser Bool
+pcom = Parser $ \ i@(Source str loc) -> here $ case str of
+  '{':'-':str -> (True, multiLine 1 str (ticks loc "{-"))
+  '-':'-':str -> (True, singleLine str (ticks loc "--"))
+  _ -> (False, i)
+
+  where
+
+  -- | Parse multi-line comments
+  multiLine :: Int -> String -> Location -> Source
+  multiLine 0 str loc = Source str loc
+  multiLine n str loc =
+    let (pref, rest) = span (`notElem` "{-") str in
+    let loc' = ticks loc pref in
+    case rest of
+      -- closing
+      '-':'}':str -> multiLine (n-1) str (ticks loc' "-}")
+      -- starting
+      '{':'-':str -> multiLine (1+n) str (ticks loc' "{-")
+      '-':'-':str ->
+        let Source end loc'' = singleLine str (ticks loc' "--") in
+        multiLine n end loc''
+      -- false alarm: ignore the unrelated '-'/'{'
+      c:str -> multiLine n str (tick loc' c)
+      -- unclosed bracket which is fine by us
+      [] -> Source [] loc'
+
+  -- | Parse single line comments
+  singleLine :: String -> Location -> Source
+  singleLine str loc = case span (/= '\n') str of
+    (cs, []) -> Source [] (ticks loc cs)
+    (cs, d:ds) -> Source ds (tick (ticks loc cs) d)
+
+-- | Remove leading spaces, an optional comment, and repeat
+pspc :: Parser ()
+pspc = do
+  Parser $ \ (Source str loc) ->
+           let (cs, rest) = span isSpace str in
+           here ((), Source rest (ticks loc cs))
+  b <- pcom
+  when b pspc
+
+-- | Remove comments; if no comment present, a single space, then more.
+pspc1 :: Parser ()
+pspc1 = do
+  b <- pcom
+  when (not b) $ () <$ pch isSpace
+  pspc
+
+-- | punctuation, as a String, which does swallow spaces
+-- This is used for expected punctuation rather than optional.
+ppunc :: String -> Parser ()
+ppunc cs = () <$ pspc <* plit cs <* pspc
+
+-- | get something that is within parentheses. Note that
+-- if we do get an opening parens, then we *expect* a closing
+-- one (i.e. 'pch' versus 'plit')
+pparens :: Parser a -> Parser a
+pparens p = id <$ pch (== '(') <* pspc <*> p <* pspc <* plit ")"
+
+-- | get something within curlies, at a point where we're expecting them
+pcurlies :: Parser a -> Parser a
+pcurlies p = id <$ ppunc "{" <*> p <* pspc <* plit "}"
+
+-- | for literal strings, i.e. enclosed in double-quotes.
+-- The code is complicated because of escapes and escaped quotes.
+pstring :: Parser String
+pstring = Parser $ \ (Source str loc) -> case str of
+  '"' : str -> maybe (notHere loc) here (go str (tick loc '"'))
+  _ -> notHere loc
+
+  where
+
+  go :: String -> Location -> Maybe (String, Source)
+  go str loc =
+    let (pref, end) = span (`notElem` "\\\"") str in
+    let loc' = ticks loc pref in
+    case end of
+      '\\':'"':end -> first ((pref ++) . ('"' :)) <$> go end (ticks loc "\\\"")
+      '\\':end -> first ((pref ++) . ('\\' :)) <$> go end (tick loc' '\\')
+      '"':end -> pure (pref, Source end (tick loc' '\"'))
+      _ -> Nothing
+
+-- | Digits into Int
+pnat :: Parser Int
+pnat = Parser $ \ (Source str loc) -> case span isDigit str of
+  (ds@(_:_), str) -> here (read ds, Source str (ticks loc ds))
+  _ -> notHere loc
+
+-- | Names (nom is the French for that) allow an alphabetic character
+-- followed by alphanumeric, underscore or quote.
+pnom :: Parser String
+pnom = Parser $
+  let isMo c = isAlphaNum c || elem c "_'" in
+  \ (Source str loc) -> case str of
+  c : cs | isAlpha c -> case span isMo cs of
+      (nm, str) -> here (c:nm, Source str (ticks loc (c : nm)))
+  _ -> notHere loc
+
+-- | an Atom is signalled by putting a single quote in front of a name
+patom :: Parser String
+patom = pch (== '\'') *> pnom
+
+-- | remove newlines (and nulls)
+pnl :: Parser ()
+pnl = () <$ pch (\c -> c == '\n' || c == '\0')
+
+-- | For a list of things of type a with a separator
+psep :: Parser () -> Parser a -> Parser [a]
+psep s p = (:) <$> p <*> many (id <$ s <*> p)
+ <|> pure []
+
+-- | For a non-empty list of things of type a with a separator
+psep1 :: Parser () -> Parser a -> Parser [a]
+psep1 s p = (:) <$> p <* s <*> psep s p
+
+-- | For a snoc list of separated list of a
+ppes :: Parser () -> Parser{--}a -> Parser (Bwd a)
+ppes s p = (B0 <><) <$> psep s p
+
+-- | The always failing parser
+pfail :: Parser a
+pfail = Parser (notHere . location)
+
+-- | Extract the location of where we are, i.e. reify it
+ploc :: Parser Location
+ploc = Parser $ \ i@(Source str loc) -> here (loc, i)
+
+-- | Given a parser of things that have ranges, make sure
+-- to reify those when parsing.
+withRange :: HasRange t => Parser t -> Parser t
+withRange p = do
+   start <- ploc
+   x <- p
+   end <- ploc
+   pure $ addRange start end x
+
+-- | Decorate something with a range when parsing it (if possible)
+pwithRange :: Parser a -> Parser (WithRange a)
+pwithRange p = withRange (WithRange unknown <$> p)
+
+-- | Are we at the end of the thing we're parsing?
 pend :: Parser ()
 pend = Parser $ \ i@(Source s loc) -> case s of
   [] -> here ((), i)
   _ -> notHere loc
 
+----------------------------------------------------------------------
+-- Dealing with errors
+
+-- | How well do we know where the error occured?
 data ErrorLocation = Precise | Imprecise
 
+-- | Turn our precision information into English
 instance Show ErrorLocation where
   show Precise = "at"
   show Imprecise = "near"
 
+-- | Hard-erroring out with a parse error
 parseError :: ErrorLocation -> Location -> String -> x
 parseError prec loc str = unsafePerformIO $ do
   putStrLn ("Parse error " ++ show prec ++ " location: " ++ show loc ++ "\n" ++ str)
   exitFailure
 
+----------------------------------------------------------------------
+-- Running an actual parser
 parse :: Show x => Parser x -> Source -> x
 parse p s = case parser (id <$> p <* pend) s of
   (_, [(x, _)]) -> x
   (Candidate ds loc, []) -> parseError Imprecise loc (renderHints ds)
   (Candidate _ loc, xs) -> parseError Imprecise loc (unlines ("Ambiguous parse:" : map (show . fst) xs))
 
+-- Parsing something which we think we already know what it is
 pmustwork :: String -> Parser x -> Parser x
 pmustwork str p = Parser $ \ i -> case parser p i of
   (_, []) -> parseError Precise (location i) str
   res -> res
 
+----------------------------------------------------------------------
+-- A Lispy thing is something that has nil, cons, and a parser
 class Lisp t where
   mkNil  :: t
   mkCons :: t -> t -> t
   pCar   :: Parser t
 
-plisp :: (Lisp t, HasRange t) => Parser t
-plisp = withRange $
-  mkNil <$ plit "]"
-  <|> id <$ plit "|" <* pspc <*> pCar <* pspc <* plit "]"
-  <|> mkCons <$> pCar <* pspc <*> plisp
+-- Parse a lispy language, with an optional transformer
+plisp :: (Lisp t, HasRange t) => Maybe (Parser t -> Parser t) -> Parser t
+plisp tr = maybe (doit id) (doit) tr
+  where
+    doit :: (Lisp t, HasRange t) => (Parser t -> Parser t) -> Parser t
+    doit tr = withRange $ id <$ pch (== '[') <* pspc <*> tr (
+      mkNil <$ plit "]"
+      <|> id <$ plit "|" <* pspc <*> pCar <* pspc <* plit "]"
+      <|> mkCons <$> pCar <* pspc <*> plisp Nothing)


### PR DESCRIPTION
Insert copious comments in Parse.
Move things around to be generally in dependency order, to make reading the code 'top down' easier (even though Haskell doesn't care). Rename 'punc' to 'ppunc' to be consistent.
Generalize 'lisp' so that what the markers are do not get distributed between here and the use site (takes an optional transformer).